### PR TITLE
pr0n Rename Update & Version Bump

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    panomosity (0.1.37)
+    panomosity (0.1.38)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/panomosity/version.rb
+++ b/lib/panomosity/version.rb
@@ -1,3 +1,3 @@
 module Panomosity
-  VERSION = '0.1.37'
+  VERSION = '0.1.38'
 end


### PR DESCRIPTION
Fixes a rare case where file naming was incorrect due to duplicates in d/e groups.

Refer to `GRAYTEST_8` fallback to duplicate.