### PR TITLE
Add export_panorama_attributes_to_csv

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,31 +1,38 @@
 PATH
   remote: .
   specs:
-    panomosity (0.1.38)
+    panomosity (0.1.39)
+      write_xlsx
 
 GEM
   remote: https://rubygems.org/
   specs:
     coderay (1.1.2)
-    diff-lcs (1.3)
+    diff-lcs (1.4.4)
     method_source (0.9.0)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rake (10.5.0)
-    rspec (3.8.0)
-      rspec-core (~> 3.8.0)
-      rspec-expectations (~> 3.8.0)
-      rspec-mocks (~> 3.8.0)
-    rspec-core (3.8.0)
-      rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.1)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-mocks (3.8.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-support (3.8.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.3)
+    rubyzip (2.3.0)
+    write_xlsx (0.85.9)
+      rubyzip (>= 1.0.0)
+      zip-zip
+    zip-zip (0.3)
+      rubyzip (>= 1.0.0)
 
 PLATFORMS
   ruby

--- a/lib/panomosity/version.rb
+++ b/lib/panomosity/version.rb
@@ -1,3 +1,3 @@
 module Panomosity
-  VERSION = '0.1.39'
+  VERSION = '0.1.40'
 end

--- a/lib/panomosity/xlsx_writer.rb
+++ b/lib/panomosity/xlsx_writer.rb
@@ -1,0 +1,40 @@
+require 'write_xlsx'
+
+module Panomosity
+  module XLSXWriter
+    SEPERATE_CSV_COLUMNS = /,(?![^\[]*\])/.freeze
+
+
+    def csv_to_xlsx(input_files, output_file)
+      input_files = Array(input_files)
+
+      logger.info "Creating #{output_file}.xlsx"
+
+      workbook = WriteXLSX.new("#{output_file}.xlsx")
+
+      input_files.each do |csv|
+        logger.info "Creating #{csv} Worksheet"
+
+        worksheet = workbook.add_worksheet(csv)
+
+        seperate_csv_columns = /,(?![^\[]*\])/
+
+        File.open(csv, "r") do |f|
+          f.each_line do |rows|
+            cells = rows.split(SEPERATE_CSV_COLUMNS)
+
+            cells.each_with_index do |cell, column|
+              row = f.lineno - 1
+              data = cell.tr_s('"', '').strip
+              worksheet.write(row, column, data)
+            end
+          end
+        end
+      end
+
+      workbook.close
+
+      logger.info "Done. Check for #{output_file}.xlsx"
+    end
+  end
+end

--- a/panomosity.gemspec
+++ b/panomosity.gemspec
@@ -24,4 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_runtime_dependency 'write_xlsx'
+
 end


### PR DESCRIPTION
Just like get_panorama_attributes which prints the
panorama attributes in json to standard out, this
method prints them out to multiple csv files. It will
create a new folder (named based on the pto file
input), 3 csv files, and an XLSX file with all 3 csv
files as individual worksheets.

In order to create this XLSX file I created a new module
called XLSX_Writer which uses the write_xlsx gem. Because
this gem only supports writing new XLSX files we have to
write the XLSX file with all 3 csv files within the same
method. Saying that the csv_to_xlsx method takes either a
string with a singular csv file name, or an array with
multiple file names.

https://www.wrike.com/open.htm?id=566725406