### PR TITLE
Implement nona-mask

### DIFF
--- a/bin/nona-mask
+++ b/bin/nona-mask
@@ -1,0 +1,157 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use File::Temp qw/tempdir/;
+use File::Spec;
+use Panotools::Script;
+
+my @parameters;
+my @files;
+my %images;
+my $outfile;
+my $script;
+my $tempdir = tempdir (CLEANUP => 1);
+
+# parse command-line parameters
+
+while (@ARGV)
+{
+    my $arg = shift @ARGV;
+    if ($arg =~ /^-o/)
+    {
+        $outfile = File::Spec->rel2abs (shift @ARGV);
+    }
+    elsif ($arg =~ /^-i/)
+    {
+      my $img = shift @ARGV;
+      $img =~ s/^([0-9]+)[^0-9]*$/$1/g;
+      $images{$img} = 1;
+    }
+    elsif ($arg =~ /^-/)
+    {
+       push @parameters, $arg;
+       push @parameters, (shift @ARGV) unless "$ARGV[0]" =~ /^-/;
+    }
+    elsif ( ! $script )
+    {
+      $script = File::Spec->rel2abs ( $arg );
+    }
+    else
+    {
+      push @files, $arg;
+    }
+}
+
+die "Usage: $0 [options] -o output project_file (image files)" unless ($outfile && $script);
+
+my $pano = new Panotools::Script;
+$pano->Read ($script);
+
+my $index = 0;
+
+# update input filenames
+
+for my $file (@files)
+{
+    $pano->Image->[$index]->{n} = "\"$file\"";
+    $index++;
+}
+
+my $i = 0;
+for my $image (@{$pano->Image})
+{
+    my $tempfile = File::Spec->catfile ($tempdir, "$i.tif");
+    my $name = $image->{n};
+    $name =~ s/(^"|"$)//g;
+    my $prefix = $name;
+    $prefix =~ s/\.[[:alnum:]]+$//i;
+
+    # prefer TIF or SVG versions if they exist
+    $name = "$prefix.tif" if (-e "$prefix.tif");
+    $name = "$prefix.svg" if (-e "$prefix.svg");
+
+    # skip mask generation if -i argument given and no mask images for those
+    if ( keys %images && ! exists $images{$i} )
+    {
+        $i++;
+        $image->{n} = "\"$name\"";
+        next;
+    }
+
+    my $mask = $prefix . '_mask.tif';
+    if (-e $mask)
+    {
+        print STDERR "Using mask $mask\n";
+        system ('composite', '-compose', 'CopyOpacity', $mask, $name, $tempfile);
+        $image->{n} = "\"$tempfile\"";
+    }
+    elsif ($name =~ /\.svg$/i)
+    {
+        print STDERR "Converting $image->{n} to TIFF\n";
+        system ('convert', '-background', 'transparent', $name, $tempfile);
+        $image->{n} = "\"$tempfile\"";
+    }
+    else
+    {
+        $image->{n} = "\"$name\"";
+    }
+    $i++;
+}
+
+my $pto_temp = "$script.nona-mask.$$.pto";
+$pano->Write ($pto_temp);
+
+foreach (keys %images) {
+  push @parameters,"-i";
+  push @parameters,$_;
+}
+system ('nona', @parameters, '-o', $outfile, $pto_temp);
+unlink $pto_temp;
+
+__END__
+
+=head1 NAME
+
+nona-mask - Wrapper around nona for managing external masks
+
+=head1 Synopsis
+
+  nona-mask [options] -o output project_file (image files)
+
+=head1 DESCRIPTION
+
+Wrapper around nona.  Usage is exactly the same as for nona,
+except that if files named '<prefix>_mask.tif' exist, they are
+inserted as alpha masks before stitching.
+
+Some examples of valid image pairs:
+
+  DSC_1234.tif DSC_1234_mask.tif
+  IMG_5678.JPG IMG_5678_mask.tif
+
+Note masks can be any bit depth, but must have no alpha channel.  Black
+indicates areas to be ignored, any other colour indicates areas that may be
+blended.
+
+Note also that only masks need to be TIFF files, input images can be any
+filetype supported by nona.
+
+Requires Panotools::Script, nona and ImageMagick.
+
+L<http://hugin.sourceforge.net/>
+
+=head1 License
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+=head1 See Also
+
+L<perl>, L<Panotools::Script>
+
+=head1 Author
+
+April 2007, Bruno Postle <bruno AT postle.net>

--- a/lib/panomosity.rb
+++ b/lib/panomosity.rb
@@ -46,6 +46,10 @@ module Panomosity
         options[:report] = report
       end
 
+      parser.on('--with-masking', 'Use nona-mask to include *_mask.tif files when running "nona_grid"') do |wm|
+        options[:with_masking] = wm
+      end
+
       parser.on('--without-cropping', 'Do not crop when running "crop_centers" (usually when the original run failed)') do |wc|
         options[:without_cropping] = wc
       end

--- a/lib/panomosity/binaries.rb
+++ b/lib/panomosity/binaries.rb
@@ -1,0 +1,6 @@
+module Panomosity
+  module Binaries
+    BASE_PATH = File.expand_path('../../bin', __dir__).freeze
+    NONA_MASK = File.expand_path('nona-mask', BASE_PATH).freeze
+  end
+end

--- a/lib/panomosity/binaries.rb
+++ b/lib/panomosity/binaries.rb
@@ -1,6 +1,8 @@
 module Panomosity
   module Binaries
     BASE_PATH = File.expand_path('../../bin', __dir__).freeze
+
     NONA_MASK = File.expand_path('nona-mask', BASE_PATH).freeze
+    NONA = 'nona'.freeze
   end
 end

--- a/lib/panomosity/runner.rb
+++ b/lib/panomosity/runner.rb
@@ -2,6 +2,7 @@ require 'logger'
 require 'json'
 require 'csv'
 require 'panomosity/xlsx_writer'
+require 'panomosity/binaries'
 
 module Panomosity
   class Runner
@@ -646,8 +647,10 @@ module Panomosity
           end
         end.compact
         save_file
+
         logger.debug "running nona #{@output}"
-        output = "nona --save-intermediate-images --intermediate-suffix=intermediate -v -m TIFF_m --seam=blend #{@output} -o #{res}_res_stitch_section_c#{column.to_s.rjust(5, '0')}_"
+        nona_binary = @options[:with_masking] ? Binaries::NONA_MASK : Binaries::NONA
+        output = "#{nona_binary} #{@output} --save-intermediate-images --intermediate-suffix=intermediate -v -m TIFF_m --seam=blend -o #{res}_res_stitch_section_c#{column.to_s.rjust(5, '0')}_"
         logger.debug output
         output
       end


### PR DESCRIPTION
The original `nona-mask` script from Panotools::Script does not forward all of our arguments properly.
We have provided [a patch for this](https://sourceforge.net/p/panotools/Panotools-Script/merge-requests/1/), but it has not yet been released.
This binary file contains that patch.

Its usage is disabled by default, and can be enabled with the `--with-masking` flag.
